### PR TITLE
feat: Add a starting inventory system

### DIFF
--- a/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
@@ -23,6 +23,33 @@ import org.terasology.world.block.Block;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * A class that allows you to specify a player's starting inventory easily.
+ *
+ * <p><strong>Note</strong> it is not possible to specify nested items (e.g. items in a chest). Stackable
+ * <em>items</em> may have a quantity greater than their maxStackSize and they will be split into multiple
+ * stacks as required. However stackable <em>blocks</em> are limited to maximum stacks of 99, any excess
+ * is ignored.</p>
+ *
+ * Example: add a delta for the player.prefab with the following
+ * <pre>
+ * {
+ *   "StartingInventory": {
+ *     "items": [
+ *       { "uri": "core:pickaxe", "quantity": 1 },
+ *       { "uri": "core:axe", "quantity": 1 },
+ *       { "uri": "core:coal", "quantity": 149 },
+ *       { "uri": "core:shovel", "quantity": 1 },
+ *       { "uri": "CoreBlocks:Torch", "quantity": 99 },
+ *       { "uri": "CoreBlocks:Torch", "quantity": 120 },
+ *       { "uri": "core:explodeTool", "quantity": 1 },
+ *       { "uri": "core:railgunTool", "quantity": 1 },
+ *       { "uri": "CoreBlocks:chest", "quantity": 1 }
+ *     ]
+ *   }
+ * }
+ * </pre>
+ */
 public class StartingInventoryComponent implements Component {
 
     public boolean provided = false;
@@ -34,8 +61,14 @@ public class StartingInventoryComponent implements Component {
     @MappedContainer
     public static class InventoryItem {
 
+        /**
+         * A resource uri, may be either a block uri or an item uri.
+         */
         public String uri;
 
+        /**
+         * Must be greater than 0.
+         */
         public int quantity = 0;
     }
 }

--- a/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.inventory;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.reflection.MappedContainer;
+import org.terasology.world.block.Block;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class StartingInventoryComponent implements Component {
+
+    public List<InventoryItem> items = new LinkedList<>();
+
+    /**
+     * A simple class connecting a resource (a {@link Block} or {@link Prefab}) to a quantity
+     */
+    @MappedContainer
+    public static class InventoryItem {
+
+        public String uri;
+
+        public int quantity = 1;
+    }
+
+}

--- a/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 public class StartingInventoryComponent implements Component {
 
+    public boolean provided = false;
     public List<InventoryItem> items = new LinkedList<>();
 
     /**
@@ -35,7 +36,6 @@ public class StartingInventoryComponent implements Component {
 
         public String uri;
 
-        public int quantity = 1;
+        public int quantity = 0;
     }
-
 }

--- a/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventoryComponent.java
@@ -52,7 +52,6 @@ import java.util.List;
  */
 public class StartingInventoryComponent implements Component {
 
-    public boolean provided = false;
     public List<InventoryItem> items = new LinkedList<>();
 
     /**

--- a/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
@@ -27,7 +27,6 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.registry.In;
-import org.terasology.utilities.Assets;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.family.BlockFamily;
 import org.terasology.world.block.items.BlockItemFactory;
@@ -56,22 +55,19 @@ public class StartingInventorySystem extends BaseComponentSystem {
         blockFactory = new BlockItemFactory(entityManager);
     }
 
-    @ReceiveEvent(components = {StartingInventoryComponent.class, InventoryComponent.class})
-    public void onStartingInventory(OnPlayerSpawnedEvent event, EntityRef entityRef) {
-        StartingInventoryComponent startingInventoryComponent =
-                entityRef.getComponent(StartingInventoryComponent.class);
-        if (!startingInventoryComponent.provided) {
-            InventoryComponent inventoryComponent = entityRef.getComponent(InventoryComponent.class);
-            if (entityRef.getParentPrefab() != null) {
-                logger.info("Adding starting inventory to {}, entity has {} slots",
-                        entityRef.getParentPrefab().getName(), inventoryComponent.itemSlots.size());
-            }
-            for (StartingInventoryComponent.InventoryItem item : startingInventoryComponent.items) {
-                addToInventory(entityRef, item, inventoryComponent);
-            }
-            startingInventoryComponent.provided = true;
-            entityRef.saveComponent(startingInventoryComponent);
+    @ReceiveEvent(components = {InventoryComponent.class})
+    public void onStartingInventory(OnPlayerSpawnedEvent event,
+                                    EntityRef entityRef,
+                                    StartingInventoryComponent startingInventoryComponent) {
+        InventoryComponent inventoryComponent = entityRef.getComponent(InventoryComponent.class);
+        if (entityRef.getParentPrefab() != null) {
+            logger.info("Adding starting inventory to {}, entity has {} slots",
+                    entityRef.getParentPrefab().getName(), inventoryComponent.itemSlots.size());
         }
+        for (StartingInventoryComponent.InventoryItem item : startingInventoryComponent.items) {
+            addToInventory(entityRef, item, inventoryComponent);
+        }
+        entityRef.removeComponent(StartingInventoryComponent.class);
     }
 
     private boolean addToInventory(EntityRef entityRef,

--- a/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
@@ -96,10 +96,8 @@ public class StartingInventorySystem extends BaseComponentSystem {
         BlockFamily blockFamily = blockManager.getBlockFamily(uri);
         boolean success = true;
         if (blockFamily != null) {
-            // try give blocks
             success = tryAddBlocks(entityRef, blockFamily, quantity, inventoryComponent);
         } else {
-            // try give items
             success = tryAddItems(entityRef, uri, quantity, inventoryComponent);
         }
         if (!success) {

--- a/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
@@ -21,6 +21,7 @@ import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
@@ -44,6 +45,9 @@ public class StartingInventorySystem extends BaseComponentSystem {
 
     @In
     EntityManager entityManager;
+
+    @In
+    PrefabManager prefabManager;
 
     BlockItemFactory blockFactory;
 
@@ -129,7 +133,7 @@ public class StartingInventorySystem extends BaseComponentSystem {
                                 InventoryComponent inventoryComponent) {
         long available = availableSlots(inventoryComponent);
         // Find out of the item is stackable
-        Prefab prefab = Assets.getPrefab(uri).orElse(null);
+        Prefab prefab = prefabManager.getPrefab(uri);
         if (prefab == null) {
             logger.error("Failed to find prefab {}", uri);
             return false;
@@ -139,7 +143,7 @@ public class StartingInventorySystem extends BaseComponentSystem {
             logger.error("Failed to find ItemComponent for {}", uri);
             return false;
         }
-        if (component.stackId.length() == 0) {
+        if (component.stackId == null || component.stackId.length() == 0) {
             // Item is not stackable, one slot used per item
             if (available >= quantity) {
                 for (int i = 0; i < quantity; ++i) {

--- a/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
+++ b/src/main/java/org/terasology/logic/inventory/StartingInventorySystem.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.inventory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnAddedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.In;
+import org.terasology.utilities.Assets;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.family.BlockFamily;
+import org.terasology.world.block.items.BlockItemFactory;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class StartingInventorySystem extends BaseComponentSystem {
+
+    private static final Logger logger = LoggerFactory.getLogger(StartingInventorySystem.class);
+
+    @In
+    BlockManager blockManager;
+
+    @In
+    InventoryManager inventoryManager;
+
+    @In
+    EntityManager entityManager;
+
+    @ReceiveEvent(components = {StartingInventoryComponent.class, InventoryComponent.class})
+    public void onStartingInventory(OnAddedComponent event, EntityRef entityRef) {
+        BlockItemFactory blockFactory = new BlockItemFactory(entityManager);
+
+        StartingInventoryComponent startingInventoryComponent =
+                entityRef.getComponent(StartingInventoryComponent.class);
+        InventoryComponent inventoryComponent = entityRef.getComponent(InventoryComponent.class);
+        logger.info("Adding starting inventory to {}, entity has {}  slots",
+                entityRef.getParentPrefab().getName(), inventoryComponent.itemSlots.size());
+
+        int addedItems = 0;
+        for (StartingInventoryComponent.InventoryItem item : startingInventoryComponent.items) {
+            String uri = item.uri;
+
+            logger.info("Adding {} {}", item.quantity, uri);
+            BlockFamily blockFamily = blockManager.getBlockFamily(uri);
+            if (blockFamily != null) {
+                // If the quantity specified exceeds the maxStackSize then nothing will be added, therefore
+                // at most one slot will be used // TODO split into maxStackSize chunks
+                if (hasSpace(inventoryComponent.itemSlots.size(), addedItems, 1)) {
+                    inventoryManager.giveItem(
+                            entityRef, EntityRef.NULL, blockFactory.newInstance(blockFamily, item.quantity));
+                    ++addedItems;
+                } else {
+                    logger.error("Insufficient inventory space to add {} {}", item.quantity, uri);
+                }
+            } else {
+                // todo get stack size from ItemComponent
+                // Find out of the item is stackable
+                Prefab prefab = Assets.getPrefab(item.uri).orElse(null);
+                if (prefab == null) {
+                    logger.error("Failed to find prefab {}", item.uri);
+                    continue;
+                }
+                ItemComponent component = prefab.getComponent(ItemComponent.class);
+                if (component == null) {
+                    logger.error("Failed to find ItemComponent for {}", item.uri);
+                    continue;
+                }
+                logger.info("'{}' {}", component.stackId, component.maxStackSize);
+                if (component.stackId.length() == 0) {
+                    // Item is not stackable, one slot used per item
+                    if (hasSpace(inventoryComponent.itemSlots.size(), addedItems, item.quantity)) {
+                        for (int i = 0; i < item.quantity; ++i) {
+                            inventoryManager.giveItem(entityRef,
+                                    EntityRef.NULL, entityManager.create(uri));
+                            ++addedItems;
+                        }
+                    } else {
+                        logger.error("Insufficient inventory space to add {} {}", item.quantity, uri);
+                    }
+                } else {
+                    // Item stackable, inventory manager will handle stacking, but we still need to know
+                    // how much we have added
+                    int numFullStacks = item.quantity / component.maxStackSize;
+                    int remainder = item.quantity % component.maxStackSize;
+                    logger.info("quantity {}, maxStack {}, full {}, rem {}",
+                            item.quantity, component.maxStackSize, numFullStacks, remainder);
+                    // Add full stacks
+                    for (int i = 0; i < numFullStacks; ++i) {
+                        for (int j = 0; j < component.maxStackSize; ++j) {
+                            inventoryManager.giveItem(entityRef,
+                                    EntityRef.NULL, entityManager.create(uri));
+                        }
+                        // Every full stack is one slot
+                        ++addedItems;
+                    }
+
+                    // Add remainder
+                    for (int i = 0; i < remainder; ++i) {
+                        inventoryManager.giveItem(entityRef,
+                                EntityRef.NULL, entityManager.create(uri));
+                    }
+                    if (remainder > 0) {
+                        ++addedItems;
+                    }
+                    logger.info("Added {} slots total", addedItems);
+                }
+
+            }
+        }
+    }
+
+    private boolean hasSpace(int numSlots, int addedSoFar, int toAdd) {
+        return addedSoFar + toAdd <= numSlots;
+    }
+}

--- a/src/test/java/org/terasology/logic/inventory/StartingInventorySystemTest.java
+++ b/src/test/java/org/terasology/logic/inventory/StartingInventorySystemTest.java
@@ -38,6 +38,7 @@ import org.terasology.world.block.items.BlockItemFactory;
 import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -100,72 +101,27 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = "test:blockFamilyA";
         inventoryItem.quantity = 1;
         component.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(component);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, component);
 
         // Assert that the block was added, only once
         assertEquals(item, inventoryComp.itemSlots.get(0));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item, atLeast(0)).exists();
         Mockito.verify(item).saveComponent(itemComp);
         Mockito.verify(entityRef, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(component);
-        Mockito.verify(entityRef, atLeast(1)).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(blockManager, atLeast(1)).getBlockFamily("test:blockFamilyA");
         Mockito.verify(blockItemFactory, atLeast(1)).newInstance(blockFamily, 1);
         Mockito.verify(entityRef).getParentPrefab();
         Mockito.verify(entityRef).send(any(BeforeItemPutInInventory.class));
         Mockito.verify(entityRef).send(any(InventorySlotChangedEvent.class));
-
-        Mockito.verifyNoMoreInteractions(entityRef, entityManager, blockManager, blockItemFactory, item);
-    }
-
-    @Test
-    public void giveBlockAlreadyProvided() {
-        ItemComponent itemComp = new ItemComponent();
-        EntityRef item = mock(EntityRef.class);
-        setupItemRef(item, itemComp, 1, 10, "blockFamilyA", 1L);
-
-        // Setup blockManager to return the correct families
-        BlockFamily blockFamily = new BlockFamilyA();
-        when(blockManager.getBlockFamily("test:blockFamilyA")).thenReturn(blockFamily);
-
-        // Setup the factory to return the right instances
-        when(blockItemFactory.newInstance(blockFamily, 1)).thenReturn(item);
-
-        // Create the starting inventory
-        StartingInventoryComponent component = new StartingInventoryComponent();
-        StartingInventoryComponent.InventoryItem inventoryItem = new StartingInventoryComponent.InventoryItem();
-        inventoryItem.uri = "test:blockFamilyA";
-        inventoryItem.quantity = 1;
-        component.items.add(inventoryItem);
-        component.provided = true;
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(component);
-
-        startingInventorySystem.onStartingInventory(null, entityRef);
-
-        // Assert that the block was NOT added
-        assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(0));
-        assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
-
-        Mockito.verify(item, times(0)).getComponent(ItemComponent.class);
-        Mockito.verify(item, times(0)).exists();
-        Mockito.verify(item, times(0)).saveComponent(itemComp);
-        Mockito.verify(entityRef, times(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(entityRef, times(0)).saveComponent(inventoryComp);
-        Mockito.verify(entityRef, times(0)).saveComponent(component);
-        Mockito.verify(entityRef, times(1)).getComponent(StartingInventoryComponent.class);
-        Mockito.verify(entityRef, times(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(blockManager, times(0)).getBlockFamily("test:blockFamilyA");
-        Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
-        Mockito.verify(entityRef, times(0)).getParentPrefab();
-        Mockito.verify(entityRef, times(0)).send(any(BeforeItemPutInInventory.class));
-        Mockito.verify(entityRef, times(0)).send(any(InventorySlotChangedEvent.class));
 
         Mockito.verifyNoMoreInteractions(entityRef, entityManager, blockManager, blockItemFactory, item);
     }
@@ -189,21 +145,21 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = "test:blockFamilyA";
         inventoryItem.quantity = 110;
         component.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(component);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, component);
 
         // Assert that the block was added, only once
         assertEquals(item, inventoryComp.itemSlots.get(0));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item, atLeast(0)).exists();
         Mockito.verify(item).saveComponent(itemComp);
         Mockito.verify(entityRef, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(component);
-        Mockito.verify(entityRef, atLeast(1)).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(blockManager, atLeast(1)).getBlockFamily("test:blockFamilyA");
         Mockito.verify(blockItemFactory, atLeast(1)).newInstance(blockFamily, 99);
@@ -237,21 +193,21 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = uri;
         inventoryItem.quantity = 1;
         component.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(component);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, component);
 
         // Assert that the item was added, only once
         assertEquals(item, inventoryComp.itemSlots.get(0));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item, atLeast(0)).exists();
         Mockito.verify(item).saveComponent(itemComp);
         Mockito.verify(entityRef, atLeast(0)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(component);
-        Mockito.verify(entityRef, atLeast(1)).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(blockManager, atLeast(1)).getBlockFamily("test:itemA");
         Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
@@ -293,9 +249,8 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = uri;
         inventoryItem.quantity = 3;
         startingInventoryComponent.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, startingInventoryComponent);
 
         assertNotEquals(item1, item2);
         assertEquals(item1, inventoryComp.itemSlots.get(0));
@@ -303,6 +258,7 @@ public class StartingInventorySystemTest {
         assertEquals(item2, inventoryComp.itemSlots.get(2));
         assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(2));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(3));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item1, atLeast(0)).exists();
@@ -314,8 +270,8 @@ public class StartingInventorySystemTest {
         Mockito.verify(item2, atLeast(0)).hashCode();
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef, times(3)).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
-        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(blockManager).getBlockFamily("test:itemA");
         Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
         Mockito.verify(entityRef).getParentPrefab();
@@ -351,14 +307,14 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = uri;
         inventoryItem.quantity = 4;
         startingInventoryComponent.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, startingInventoryComponent);
 
         assertEquals(item1, inventoryComp.itemSlots.get(0));
         assertEquals(item1, inventoryComp.itemSlots.get(1));
         assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(2));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item1, atLeast(0)).exists();
@@ -366,8 +322,8 @@ public class StartingInventorySystemTest {
         Mockito.verify(item1, atLeast(0)).hashCode();
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef, times(2)).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
-        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(blockManager).getBlockFamily(uri);
         Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
         Mockito.verify(entityRef).getParentPrefab();
@@ -408,9 +364,8 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = uri;
         inventoryItem.quantity = 2;
         startingInventoryComponent.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, startingInventoryComponent);
 
         // Assert that the 4 items from the first InventoryItem were added, and the 2 from the second weren't
         assertEquals(item1, inventoryComp.itemSlots.get(0));
@@ -419,6 +374,7 @@ public class StartingInventorySystemTest {
         assertEquals(item1, inventoryComp.itemSlots.get(3));
         assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(3));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(4));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item1, atLeast(0)).exists();
@@ -426,8 +382,8 @@ public class StartingInventorySystemTest {
         Mockito.verify(item1, atLeast(0)).hashCode();
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef, times(4)).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
-        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(blockManager, times(2)).getBlockFamily("test:itemA");
         Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
         Mockito.verify(entityRef).getParentPrefab();
@@ -476,9 +432,8 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = uri2;
         inventoryItem.quantity = 2;
         startingInventoryComponent.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, startingInventoryComponent);
 
         // Assert that the 3 items from the first InventoryItem were added,
         // and the 2 from the second were added in 1 stack
@@ -488,6 +443,7 @@ public class StartingInventorySystemTest {
         assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(2));
         assertEquals(item2, inventoryComp.itemSlots.get(3));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(4));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item1, atLeast(0)).exists();
@@ -499,8 +455,8 @@ public class StartingInventorySystemTest {
         Mockito.verify(item2, atLeast(0)).hashCode();
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef, times(4)).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
-        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(blockManager).getBlockFamily(uri1);
         Mockito.verify(blockManager).getBlockFamily(uri2);
         Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
@@ -551,9 +507,8 @@ public class StartingInventorySystemTest {
         inventoryItem.uri = "test:itemB";
         inventoryItem.quantity = 2;
         startingInventoryComponent.items.add(inventoryItem);
-        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
 
-        startingInventorySystem.onStartingInventory(null, entityRef);
+        startingInventorySystem.onStartingInventory(null, entityRef, startingInventoryComponent);
 
         // Assert that the 3 items from the first InventoryItem were added,
         // and the 2 from the second weren't because it can't find a prefab
@@ -563,6 +518,7 @@ public class StartingInventorySystemTest {
         assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(2));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(3));
         assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(4));
+        assertFalse(entityRef.hasComponent(StartingInventoryComponent.class));
 
         Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item1, atLeast(0)).exists();
@@ -574,8 +530,8 @@ public class StartingInventorySystemTest {
         Mockito.verify(item2, atLeast(0)).hashCode();
         Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(entityRef, times(3)).saveComponent(inventoryComp);
-        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
-        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).removeComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef).hasComponent(StartingInventoryComponent.class);
         Mockito.verify(blockManager).getBlockFamily("test:itemA");
         Mockito.verify(blockManager).getBlockFamily("test:itemB");
         Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);

--- a/src/test/java/org/terasology/logic/inventory/StartingInventorySystemTest.java
+++ b/src/test/java/org/terasology/logic/inventory/StartingInventorySystemTest.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.entitySystem.prefab.PrefabManager;
 import org.terasology.logic.inventory.events.BeforeItemPutInInventory;
 import org.terasology.logic.inventory.events.InventorySlotChangedEvent;
 import org.terasology.math.Side;
@@ -35,7 +37,9 @@ import org.terasology.world.block.items.BlockItemFactory;
 import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -49,22 +53,20 @@ public class StartingInventorySystemTest {
 
     private InventoryAuthoritySystem inventoryAuthoritySystem;
     private StartingInventorySystem startingInventorySystem;
-    private EntityRef instigator;
-    private EntityRef inventory;
+    private EntityRef entityRef;
     private InventoryComponent inventoryComp;
     private EntityManager entityManager;
     private BlockManager blockManager;
-    private InventoryManager inventoryManager;
     private BlockItemFactory blockItemFactory;
+    private PrefabManager prefabManager;
 
     @Before
     public void setup() {
         inventoryAuthoritySystem = new InventoryAuthoritySystem();
         startingInventorySystem = new StartingInventorySystem();
-        instigator = mock(EntityRef.class);
-        inventory = mock(EntityRef.class);
+        entityRef = mock(EntityRef.class);
         inventoryComp = new InventoryComponent(5);
-        when(inventory.getComponent(InventoryComponent.class)).thenReturn(inventoryComp);
+        when(entityRef.getComponent(InventoryComponent.class)).thenReturn(inventoryComp);
 
         entityManager = mock(EntityManager.class);
         inventoryAuthoritySystem.setEntityManager(entityManager);
@@ -72,9 +74,10 @@ public class StartingInventorySystemTest {
         blockManager = mock(BlockManager.class);
         startingInventorySystem.blockManager = blockManager;
         startingInventorySystem.inventoryManager = inventoryAuthoritySystem;
-        inventoryManager = inventoryAuthoritySystem;
         blockItemFactory = mock(BlockItemFactory.class);
         startingInventorySystem.blockFactory = blockItemFactory;
+        prefabManager = mock(PrefabManager.class);
+        startingInventorySystem.prefabManager = prefabManager;
     }
 
     // test give block
@@ -86,11 +89,10 @@ public class StartingInventorySystemTest {
     // test provided not added again
 
     @Test
-    public void giveBlock() {
+    public void giveSingleBlock() {
         ItemComponent itemComp = new ItemComponent();
         EntityRef item = mock(EntityRef.class);
-        setupItemRef(item, itemComp, 2, 10);
-        logger.debug("Item {}", item);
+        setupItemRef(item, itemComp, 1, 10, "blockFamilyA", 1L);
 
         // Setup blockManager to return the correct families
         BlockFamily blockFamily = new BlockFamilyA();
@@ -99,57 +101,223 @@ public class StartingInventorySystemTest {
         // Setup the factory to return the right instances
         when(blockItemFactory.newInstance(blockFamily, 1)).thenReturn(item);
 
-        logger.debug("Calling");
-
         // Create the starting inventory
         StartingInventoryComponent component = new StartingInventoryComponent();
         StartingInventoryComponent.InventoryItem inventoryItem = new StartingInventoryComponent.InventoryItem();
         inventoryItem.uri = "test:blockFamilyA";
         inventoryItem.quantity = 1;
         component.items.add(inventoryItem);
-        when(inventory.getComponent(StartingInventoryComponent.class)).thenReturn(component);
+        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(component);
 
-        startingInventorySystem.onStartingInventory(null, inventory);
+        startingInventorySystem.onStartingInventory(null, entityRef);
+
+        // Assert that the block was added, only once
+        assertEquals(item, inventoryComp.itemSlots.get(0));
+        assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
 
         Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
         Mockito.verify(item, atLeast(0)).exists();
         Mockito.verify(item).saveComponent(itemComp);
-        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
-        Mockito.verify(inventory).saveComponent(inventoryComp);
-        Mockito.verify(inventory).saveComponent(component);
-        Mockito.verify(item).hashCode();
-        Mockito.verify(inventory, atLeast(1)).getComponent(StartingInventoryComponent.class);
-        Mockito.verify(inventory, atLeast(1)).getComponent(InventoryComponent.class);
+        Mockito.verify(entityRef, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(entityRef).saveComponent(inventoryComp);
+        Mockito.verify(entityRef).saveComponent(component);
+        Mockito.verify(entityRef, atLeast(1)).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
         Mockito.verify(blockManager, atLeast(1)).getBlockFamily("test:blockFamilyA");
         Mockito.verify(blockItemFactory, atLeast(1)).newInstance(blockFamily, 1);
-        Mockito.verify(inventory, atLeast(1)).getParentPrefab();
-        Mockito.verify(inventory, times(1)).send(any(BeforeItemPutInInventory.class));
-        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(entityRef).getParentPrefab();
+        Mockito.verify(entityRef).send(any(BeforeItemPutInInventory.class));
+        Mockito.verify(entityRef).send(any(InventorySlotChangedEvent.class));
 
-        Mockito.verifyNoMoreInteractions(inventory, entityManager, blockManager, blockItemFactory, item);
-
-        assertEquals(item, inventoryComp.itemSlots.get(0));
+        Mockito.verifyNoMoreInteractions(entityRef, entityManager, blockManager, blockItemFactory, item);
     }
 
-    private void setupItemRef(EntityRef item, ItemComponent itemComp, int stackCount, int stackSize) {
-        itemComp.stackCount = (byte) stackCount;
-        itemComp.maxStackSize = (byte) stackSize;
-        itemComp.stackId = "stackId";
-        when(item.exists()).thenReturn(true);
-        when(item.getComponent(ItemComponent.class)).thenReturn(itemComp);
-        when(item.iterateComponents()).thenReturn(new LinkedList<>());
-    }
-
-    private EntityRef createItem(String stackId, int stackCount, int stackSize) {
+    @Test
+    public void giveSingleItem() {
         ItemComponent itemComp = new ItemComponent();
+        EntityRef item = mock(EntityRef.class);
+        setupItemRef(item, itemComp, 1, 10, "itemA", 1L);
+
+        // Setup blockManager to return bull block family
+        BlockFamily blockFamily = new BlockFamilyA();
+        when(blockManager.getBlockFamily(anyString())).thenReturn(null);
+
+        // Setup to return item prefab
+        Prefab prefab = mock(Prefab.class);
+        when(prefab.getComponent(ItemComponent.class)).thenReturn(itemComp);
+        String uri = "test:itemA";
+        when(prefabManager.getPrefab(uri)).thenReturn(prefab);
+        when(entityManager.create(uri)).thenReturn(item);
+
+        // Create the starting inventory
+        StartingInventoryComponent component = new StartingInventoryComponent();
+        StartingInventoryComponent.InventoryItem inventoryItem = new StartingInventoryComponent.InventoryItem();
+        inventoryItem.uri = uri;
+        inventoryItem.quantity = 1;
+        component.items.add(inventoryItem);
+        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(component);
+
+        startingInventorySystem.onStartingInventory(null, entityRef);
+
+        // Assert that the item was added, only once
+        assertEquals(item, inventoryComp.itemSlots.get(0));
+        assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(1));
+
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(item).saveComponent(itemComp);
+        Mockito.verify(entityRef, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(entityRef).saveComponent(inventoryComp);
+        Mockito.verify(entityRef).saveComponent(component);
+        Mockito.verify(entityRef, atLeast(1)).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
+        Mockito.verify(blockManager, atLeast(1)).getBlockFamily("test:itemA");
+        Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
+        Mockito.verify(entityRef).getParentPrefab();
+        Mockito.verify(entityRef).send(any(BeforeItemPutInInventory.class));
+        Mockito.verify(entityRef).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(entityManager).create(uri);
+
+        Mockito.verifyNoMoreInteractions(entityRef, entityManager, blockManager, blockItemFactory, item);
+    }
+
+    @Test
+    public void giveNonStackableItem() {
+        // Create separate entities for equality checking
+        ItemComponent itemComp1 = new ItemComponent();
+        EntityRef item1 = mock(EntityRef.class);
+        setupItemRef(item1, itemComp1, 1, 1, "", 1L);
+        logger.debug("item1 {}", item1);
+
+        ItemComponent itemComp2 = new ItemComponent();
+        EntityRef item2 = mock(EntityRef.class);
+        setupItemRef(item2, itemComp2, 1, 1, "", 2L);
+        logger.debug("item2 {}", item2);
+
+        // Setup blockManager to return bull block family
+        BlockFamily blockFamily = new BlockFamilyA();
+        when(blockManager.getBlockFamily(anyString())).thenReturn(null);
+
+        // Setup to return item prefab
+        Prefab prefab = mock(Prefab.class);
+        when(prefab.getComponent(ItemComponent.class)).thenReturn(itemComp1);
+        String uri = "test:itemA";
+        when(prefabManager.getPrefab(uri)).thenReturn(prefab);
+        when(entityManager.create(uri)).thenReturn(item1).thenReturn(item2);
+
+        // Create the starting inventory
+        StartingInventoryComponent startingInventoryComponent = new StartingInventoryComponent();
+        StartingInventoryComponent.InventoryItem inventoryItem = new StartingInventoryComponent.InventoryItem();
+        inventoryItem.uri = uri;
+        inventoryItem.quantity = 3;
+        startingInventoryComponent.items.add(inventoryItem);
+        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
+
+        startingInventorySystem.onStartingInventory(null, entityRef);
+
+        assertNotEquals(item1, item2);
+        assertEquals(item1, inventoryComp.itemSlots.get(0));
+        assertEquals(item2, inventoryComp.itemSlots.get(1));
+        assertEquals(item2, inventoryComp.itemSlots.get(2));
+        assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(2));
+        assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(3));
+
+        Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item1, atLeast(0)).exists();
+        Mockito.verify(item1, times(1)).saveComponent(itemComp1);
+        Mockito.verify(item1, atLeast(0)).hashCode();
+        Mockito.verify(item2, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item2, atLeast(0)).exists();
+        Mockito.verify(item2, times(2)).saveComponent(itemComp2);
+        Mockito.verify(item2, atLeast(0)).hashCode();
+        Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
+        Mockito.verify(entityRef, times(3)).saveComponent(inventoryComp);
+        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
+        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(blockManager).getBlockFamily("test:itemA");
+        Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
+        Mockito.verify(entityRef).getParentPrefab();
+        Mockito.verify(entityRef, times(3)).send(any(BeforeItemPutInInventory.class));
+        Mockito.verify(entityRef, times(3)).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(entityManager, times(3)).create(uri);
+
+        Mockito.verifyNoMoreInteractions(entityRef, entityManager, blockManager, blockItemFactory, item1, item2);
+    }
+
+    @Test
+    public void giveTooManyNonStackableItem() {
+        // Create separate entities for equality checking
+        ItemComponent itemComp1 = new ItemComponent();
+        EntityRef item1 = mock(EntityRef.class);
+        setupItemRef(item1, itemComp1, 1, 1, "", 1L);
+        logger.debug("item1 {}", item1);
+
+        // Setup blockManager to return bull block family
+        BlockFamily blockFamily = new BlockFamilyA();
+        when(blockManager.getBlockFamily(anyString())).thenReturn(null);
+
+        // Setup to return item prefab
+        Prefab prefab = mock(Prefab.class);
+        when(prefab.getComponent(ItemComponent.class)).thenReturn(itemComp1);
+        String uri = "test:itemA";
+        when(prefabManager.getPrefab(uri)).thenReturn(prefab);
+        when(entityManager.create(uri)).thenReturn(item1);
+
+        // Create the starting inventory
+        // Add 4 items, then try to add 2 more which should fail
+        StartingInventoryComponent startingInventoryComponent = new StartingInventoryComponent();
+        StartingInventoryComponent.InventoryItem inventoryItem = new StartingInventoryComponent.InventoryItem();
+        inventoryItem.uri = uri;
+        inventoryItem.quantity = 4;
+        startingInventoryComponent.items.add(inventoryItem);
+        inventoryItem = new StartingInventoryComponent.InventoryItem();
+        inventoryItem.uri = uri;
+        inventoryItem.quantity = 2;
+        startingInventoryComponent.items.add(inventoryItem);
+        when(entityRef.getComponent(StartingInventoryComponent.class)).thenReturn(startingInventoryComponent);
+
+        startingInventorySystem.onStartingInventory(null, entityRef);
+
+        // Assert that the 4 items from the first InventoryItem were added, and the 2 from the second weren't
+        assertEquals(item1, inventoryComp.itemSlots.get(0));
+        assertEquals(item1, inventoryComp.itemSlots.get(1));
+        assertEquals(item1, inventoryComp.itemSlots.get(2));
+        assertEquals(item1, inventoryComp.itemSlots.get(3));
+        assertNotEquals(EntityRef.NULL, inventoryComp.itemSlots.get(3));
+        assertEquals(EntityRef.NULL, inventoryComp.itemSlots.get(4));
+
+        Mockito.verify(item1, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item1, atLeast(0)).exists();
+        Mockito.verify(item1, times(4)).saveComponent(itemComp1);
+        Mockito.verify(item1, atLeast(0)).hashCode();
+        Mockito.verify(entityRef, atLeast(1)).getComponent(InventoryComponent.class);
+        Mockito.verify(entityRef, times(4)).saveComponent(inventoryComp);
+        Mockito.verify(entityRef).saveComponent(startingInventoryComponent);
+        Mockito.verify(entityRef).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(blockManager, times(2)).getBlockFamily("test:itemA");
+        Mockito.verify(blockItemFactory, times(0)).newInstance(blockFamily, 1);
+        Mockito.verify(entityRef).getParentPrefab();
+        Mockito.verify(entityRef, times(4)).send(any(BeforeItemPutInInventory.class));
+        Mockito.verify(entityRef, times(4)).send(any(InventorySlotChangedEvent.class));
+        Mockito.verify(entityManager, times(4)).create(uri);
+
+        Mockito.verifyNoMoreInteractions(entityRef, entityManager, blockManager, blockItemFactory, item1);
+    }
+
+    //=======================================================================================
+    private void setupItemRef(EntityRef item,
+                              ItemComponent itemComp,
+                              int stackCount,
+                              int stackSize,
+                              String stackId,
+                              long id) {
         itemComp.stackCount = (byte) stackCount;
         itemComp.maxStackSize = (byte) stackSize;
         itemComp.stackId = stackId;
-        EntityRef item = mock(EntityRef.class);
         when(item.exists()).thenReturn(true);
         when(item.getComponent(ItemComponent.class)).thenReturn(itemComp);
         when(item.iterateComponents()).thenReturn(new LinkedList<>());
-        return item;
+        when(item.getId()).thenReturn(id);
     }
 
     //=======================================================================================
@@ -195,48 +363,4 @@ public class StartingInventorySystemTest {
             return false;
         }
     }
-
-    public static class BlockFamilyB implements BlockFamily {
-
-        @Override
-        public BlockUri getURI() {
-            return new BlockUri("test:blockFamilyB");
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "Block Family B";
-        }
-
-        @Override
-        public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
-            return null;
-        }
-
-        @Override
-        public Block getArchetypeBlock() {
-            return new Block();
-        }
-
-        @Override
-        public Block getBlockFor(BlockUri blockUri) {
-            return new Block();
-        }
-
-        @Override
-        public Iterable<Block> getBlocks() {
-            return null;
-        }
-
-        @Override
-        public Iterable<String> getCategories() {
-            return null;
-        }
-
-        @Override
-        public boolean hasCategory(String category) {
-            return false;
-        }
-    }
-
 }

--- a/src/test/java/org/terasology/logic/inventory/StartingInventorySystemTest.java
+++ b/src/test/java/org/terasology/logic/inventory/StartingInventorySystemTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.logic.inventory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.inventory.events.BeforeItemPutInInventory;
+import org.terasology.logic.inventory.events.InventorySlotChangedEvent;
+import org.terasology.math.Side;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.BlockUri;
+import org.terasology.world.block.family.BlockFamily;
+import org.terasology.world.block.items.BlockItemFactory;
+
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+/**
+ */
+public class StartingInventorySystemTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(StartingInventorySystemTest.class);
+
+    private InventoryAuthoritySystem inventoryAuthoritySystem;
+    private StartingInventorySystem startingInventorySystem;
+    private EntityRef instigator;
+    private EntityRef inventory;
+    private InventoryComponent inventoryComp;
+    private EntityManager entityManager;
+    private BlockManager blockManager;
+    private InventoryManager inventoryManager;
+    private BlockItemFactory blockItemFactory;
+
+    @Before
+    public void setup() {
+        inventoryAuthoritySystem = new InventoryAuthoritySystem();
+        startingInventorySystem = new StartingInventorySystem();
+        instigator = mock(EntityRef.class);
+        inventory = mock(EntityRef.class);
+        inventoryComp = new InventoryComponent(5);
+        when(inventory.getComponent(InventoryComponent.class)).thenReturn(inventoryComp);
+
+        entityManager = mock(EntityManager.class);
+        inventoryAuthoritySystem.setEntityManager(entityManager);
+        startingInventorySystem.entityManager = entityManager;
+        blockManager = mock(BlockManager.class);
+        startingInventorySystem.blockManager = blockManager;
+        startingInventorySystem.inventoryManager = inventoryAuthoritySystem;
+        inventoryManager = inventoryAuthoritySystem;
+        blockItemFactory = mock(BlockItemFactory.class);
+        startingInventorySystem.blockFactory = blockItemFactory;
+    }
+
+    // test give block
+
+    // test give item
+
+    // test does try add too much
+
+    // test provided not added again
+
+    @Test
+    public void giveBlock() {
+        ItemComponent itemComp = new ItemComponent();
+        EntityRef item = mock(EntityRef.class);
+        setupItemRef(item, itemComp, 2, 10);
+        logger.debug("Item {}", item);
+
+        // Setup blockManager to return the correct families
+        BlockFamily blockFamily = new BlockFamilyA();
+        when(blockManager.getBlockFamily("test:blockFamilyA")).thenReturn(blockFamily);
+
+        // Setup the factory to return the right instances
+        when(blockItemFactory.newInstance(blockFamily, 1)).thenReturn(item);
+
+        logger.debug("Calling");
+
+        // Create the starting inventory
+        StartingInventoryComponent component = new StartingInventoryComponent();
+        StartingInventoryComponent.InventoryItem inventoryItem = new StartingInventoryComponent.InventoryItem();
+        inventoryItem.uri = "test:blockFamilyA";
+        inventoryItem.quantity = 1;
+        component.items.add(inventoryItem);
+        when(inventory.getComponent(StartingInventoryComponent.class)).thenReturn(component);
+
+        startingInventorySystem.onStartingInventory(null, inventory);
+
+        Mockito.verify(item, atLeast(0)).getComponent(ItemComponent.class);
+        Mockito.verify(item, atLeast(0)).exists();
+        Mockito.verify(item).saveComponent(itemComp);
+        Mockito.verify(inventory, atLeast(0)).getComponent(InventoryComponent.class);
+        Mockito.verify(inventory).saveComponent(inventoryComp);
+        Mockito.verify(inventory).saveComponent(component);
+        Mockito.verify(item).hashCode();
+        Mockito.verify(inventory, atLeast(1)).getComponent(StartingInventoryComponent.class);
+        Mockito.verify(inventory, atLeast(1)).getComponent(InventoryComponent.class);
+        Mockito.verify(blockManager, atLeast(1)).getBlockFamily("test:blockFamilyA");
+        Mockito.verify(blockItemFactory, atLeast(1)).newInstance(blockFamily, 1);
+        Mockito.verify(inventory, atLeast(1)).getParentPrefab();
+        Mockito.verify(inventory, times(1)).send(any(BeforeItemPutInInventory.class));
+        Mockito.verify(inventory, times(1)).send(any(InventorySlotChangedEvent.class));
+
+        Mockito.verifyNoMoreInteractions(inventory, entityManager, blockManager, blockItemFactory, item);
+
+        assertEquals(item, inventoryComp.itemSlots.get(0));
+    }
+
+    private void setupItemRef(EntityRef item, ItemComponent itemComp, int stackCount, int stackSize) {
+        itemComp.stackCount = (byte) stackCount;
+        itemComp.maxStackSize = (byte) stackSize;
+        itemComp.stackId = "stackId";
+        when(item.exists()).thenReturn(true);
+        when(item.getComponent(ItemComponent.class)).thenReturn(itemComp);
+        when(item.iterateComponents()).thenReturn(new LinkedList<>());
+    }
+
+    private EntityRef createItem(String stackId, int stackCount, int stackSize) {
+        ItemComponent itemComp = new ItemComponent();
+        itemComp.stackCount = (byte) stackCount;
+        itemComp.maxStackSize = (byte) stackSize;
+        itemComp.stackId = stackId;
+        EntityRef item = mock(EntityRef.class);
+        when(item.exists()).thenReturn(true);
+        when(item.getComponent(ItemComponent.class)).thenReturn(itemComp);
+        when(item.iterateComponents()).thenReturn(new LinkedList<>());
+        return item;
+    }
+
+    //=======================================================================================
+    public static class BlockFamilyA implements BlockFamily {
+
+        @Override
+        public BlockUri getURI() {
+            return new BlockUri("test:blockFamilyA");
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Block Family A";
+        }
+
+        @Override
+        public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
+            return null;
+        }
+
+        @Override
+        public Block getArchetypeBlock() {
+            return new Block();
+        }
+
+        @Override
+        public Block getBlockFor(BlockUri blockUri) {
+            return new Block();
+        }
+
+        @Override
+        public Iterable<Block> getBlocks() {
+            return null;
+        }
+
+        @Override
+        public Iterable<String> getCategories() {
+            return null;
+        }
+
+        @Override
+        public boolean hasCategory(String category) {
+            return false;
+        }
+    }
+
+    public static class BlockFamilyB implements BlockFamily {
+
+        @Override
+        public BlockUri getURI() {
+            return new BlockUri("test:blockFamilyB");
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Block Family B";
+        }
+
+        @Override
+        public Block getBlockForPlacement(Vector3i location, Side attachmentSide, Side direction) {
+            return null;
+        }
+
+        @Override
+        public Block getArchetypeBlock() {
+            return new Block();
+        }
+
+        @Override
+        public Block getBlockFor(BlockUri blockUri) {
+            return new Block();
+        }
+
+        @Override
+        public Iterable<Block> getBlocks() {
+            return null;
+        }
+
+        @Override
+        public Iterable<String> getCategories() {
+            return null;
+        }
+
+        @Override
+        public boolean hasCategory(String category) {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request for Terasology! :-)
Please fill in some details about the PR, below.
If the PR contains source code please make sure to run Checkstyle on it first.
If you add unit tests we'll love you forever! 

You might also want to read "How to Work on a PR Efficiently":
https://github.com/MovingBlocks/Terasology/wiki/How-to-Work-on-a-PR-Efficiently
-->

### Contains

Adds a ```StartingInventorySystem``` so that starting inventory may be specified without requiring a custom system (As is in e.g. CoreSampleGameplay or CombatSystem). The inventory will only be provided once. Not on respawn or re-entry.

### How to test

Add a delta for the player prefab and add something like the following:
```
{
  "StartingInventory": {
    "items": [
      { "uri": "core:pickaxe", "quantity": 1 },
      { "uri": "core:axe", "quantity": 1 },
      { "uri": "core:shovel", "quantity": 1 },
      { "uri": "CoreBlocks:Torch", "quantity": 99 },
      { "uri": "core:explodeTool", "quantity": 1 },
      { "uri": "core:railgunTool", "quantity": 1 },
      { "uri": "CoreBlocks:chest", "quantity": 1 }
    ]
  }
}
```
You should see those items in your inventory (plus some log entries as well). If you then drop all of them and log out and back in you should see that you aren't provided the items again.

Note if you're testing in CoreSampleGameplay or CombatSystem you should disable the starting inventory system.

### Outstanding before merging

- [x] Add unit tests
