### PR TITLE
feat(commands): add `remove` command

### DIFF
--- a/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -282,7 +282,7 @@ public class ItemCommands extends BaseComponentSystem {
             if (removedItems > 0) {
                 return "You removed "
                         + (removedItems > 1 ? removedItems + " items of " : "an item of ")
-                        + prefab.getName()
+                        + prefab.getName();
             } else {    // can also mean that all removal attempts failed
                 return "Nothing to remove, you don't have \""
                         + prefab.getName()

--- a/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -282,10 +282,10 @@ public class ItemCommands extends BaseComponentSystem {
             if (removedItems > 0) {
                 return "You removed "
                         + (removedItems > 1 ? removedItems + " items of " : "an item of ")
-                        + prefab.getName();
+                        + prefab.getName()
             } else {    // can also mean that all removal attempts failed
                 return "Nothing to remove, you don't have \""
-                        + prefab.getName();
+                        + prefab.getName()
                         + "\" in your inventory";
             }
         }

--- a/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -231,7 +231,7 @@ public class ItemCommands extends BaseComponentSystem {
         return builder.toString();
     }
 
-    private String removeItem(Prefab itemPrefab, int removalQuantity, EntityRef client) {
+    private String removeItem(Prefab prefab, int removalQuantity, EntityRef client) {
 
         if (prefab != null && prefab.hasComponent(ItemComponent.class)) {
             boolean isStackable = !prefab.getComponent(ItemComponent.class).stackId.isEmpty();
@@ -289,6 +289,8 @@ public class ItemCommands extends BaseComponentSystem {
                         + "\" in your inventory";
             }
         }
+
+        return null;
     }
 
 

--- a/src/main/java/org/terasology/logic/inventory/ItemCommands.java
+++ b/src/main/java/org/terasology/logic/inventory/ItemCommands.java
@@ -134,25 +134,27 @@ public class ItemCommands extends BaseComponentSystem {
             requiredPermission = PermissionManager.CHEAT_PERMISSION)
     public String remove(
             @Sender EntityRef client,
-            @CommandParam("prefabId") String inventoryObjectId,
-            @CommandParam(value = "quantity", required = false) Integer quantity,
+            @CommandParam("objectID") String inventoryObjectId,
+            @CommandParam(value = "quantity", required = false) Integer inputQuantity,
             @CommandParam(value = "blockShapeName", required = false) String shapeUriParam) {
 
-        int removalQuantity = quantity != null ? quantity : 1;
+        int removalQuantity = inputQuantity != null ? inputQuantity : 1;
         if (removalQuantity < 1) {
-            return "Invalid quantity of items!";
+            return "Invalid quantity of objects to remove!";
         }
 
-        String message;
+        String message = null;
         Set<ResourceUrn> matches = assetManager.resolve(inventoryObjectId, Prefab.class);
         if (matches.size() == 1) {
             Prefab prefab = assetManager.getAsset(matches.iterator().next(), Prefab.class).orElse(null);
-            message = removeItem(prefab, quantity, client);
+            message = removeItem(prefab, removalQuantity, client);
         } else if (matches.size() > 1) {
             message = buildAmbiguousObjectIdString("item", inventoryObjectId, matches);
-        } else {
+        }
+
+        if (message == null) {
             // If no matches are found for items, try blocks
-            message = removeBlock(client, inventoryObjectId, quantity, shapeUriParam);
+            message = removeBlock(client, inventoryObjectId, removalQuantity, shapeUriParam);
         }
 
         if (message != null) {


### PR DESCRIPTION
Replaces and closes #1 

Adding a command to remove items from inventory.

# How to test
1. Give a few pickaxes using "give pickaxe 'amount' " command
1. Remove one pickaxe using "remove pickaxe" 
1. Remove many pickaxes using "remove pickaxe amount" with various values of the amount
1. Try the remove command when you don't have a pickaxe in the inventory
1. Try the remove command with amount parameter greater than the amount of pickaxe you have in your inventory.

Test the steps 1 to 5 for blocks, shapes and stackable objects, too.

# Outstanding before merging this PR
- [x] removing multiple stackable items
- [x] removing more blocks than are in the inventory (remove those that exist and print how many were removed)

# Follow-up tasks to merging this PR
- overhauling the remove command code (remove code duplication due to sequential handling of item and block removal)
- overhauling the give command code (remove code duplication due to sequential handling of item and block removal)

Co-authored-by: Darshan <darshantank3@gmail.com>