### PR TITLE
build(gh-workflow): Add Github workflow to build and test module

### DIFF
--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -1,4 +1,4 @@
-name: Build, Test, and Upload Artifacts
+name: Build, Test, and run Static Code Analysis
 
 on:
   push:

--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -10,40 +10,48 @@ on:
 jobs:
   build:
     name: Build / Test / Static Analysis
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout Engine
-          uses: actions/checkout@v2
-          with:
-            repository: MovingBlocks/Terasology
-        - uses: actions/cache@v1
-          name: Restore gradle cache
-          with:
-            path: ~/.gradle/caches
-            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-            restore-keys: |
-              ${{ runner.OS }}-gradle-${{ env.cache-name }}-
-              ${{ runner.OS }}-gradle-
-              ${{ runner.OS }}-
-        - uses: actions/cache@v1
-          name: Restore gradle wrapper
-          with:
-            path: ~/.gradle/wrapper
-            key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-        - name: Checkout Module
-          uses: actions/checkout@v2
-          with:
-            path: modules/${{ github.event.repository.name }}
-        - name: Set up JDK 8
-          uses: actions/setup-java@v1
-          with:
-            java-version: 8
-        - name: Refresh Module Build Files
-          run: ./groovyw module refresh
-        - name: Build module JAR
-          run: ./gradlew :modules:${{ github.event.repository.name }}:jar
-        - name: Tests
-          run: ./gradlew :modules:${{ github.event.repository.name }}:test
-        - name: Static Code Analysis
-          run: ./gradlew :modules:${{ github.event.repository.name }}:check -x test
-          continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Engine
+        uses: actions/checkout@v2
+        with:
+          repository: MovingBlocks/Terasology
+          ref: develop
+      - uses: actions/cache@v1
+        name: Restore gradle cache
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-${{ env.cache-name }}-
+            ${{ runner.OS }}-gradle-
+            ${{ runner.OS }}-
+      - uses: actions/cache@v1
+        name: Restore gradle wrapper
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Checkout Module
+        uses: actions/checkout@v2
+        with:
+          path: modules/${{ github.event.repository.name }}
+          clean: true
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Copy build.gradle
+        run: cp ./templates/build.gradle modules/${{ github.event.repository.name }}/build.gradle
+      - name: Build module JAR
+        run: ./gradlew :modules:${{ github.event.repository.name }}:jar
+      - name: Tests
+        run: ./gradlew :modules:${{ github.event.repository.name }}:test --console=plain
+      - name: check-run-reporter
+        uses: check-run-reporter/action@master
+        env:
+          CHECK_RUN_REPORTER_LABEL: 'Unit Tests'
+          CHECK_RUN_REPORTER_REPORT: 'modules/${{ github.event.repository.name }}/build/test-results/test/*.xml'
+          CHECK_RUN_REPORTER_TOKEN: ${{ secrets.CHECK_RUN_REPORTER_TOKEN }}
+      - name: Static Code Analysis
+        run: ./gradlew :modules:${{ github.event.repository.name }}:check --exclude-task test
+        continue-on-error: true

--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build / Test / Publish
+    name: Build / Test / Static Analysis
       runs-on: ubuntu-latest
       steps:
         - name: Checkout Engine
@@ -40,19 +40,10 @@ jobs:
             java-version: 8
         - name: Refresh Module Build Files
           run: ./groovyw module refresh
-        - name: Get module version
-          run: echo ::set-env name=MODULE_VERSION::$(./gradlew :modules:${{ github.event.repository.name }}:properties | grep "version:" | awk '{print $2}')
-          shell: bash
         - name: Build module JAR
           run: ./gradlew :modules:${{ github.event.repository.name }}:jar
-        - name: Test
+        - name: Tests
           run: ./gradlew :modules:${{ github.event.repository.name }}:test
-        - name: Check
-          run: ./gradlew :modules:${{ github.event.repository.name }}:check
+        - name: Static Code Analysis
+          run: ./gradlew :modules:${{ github.event.repository.name }}:check -x test
           continue-on-error: true
-        - name: Upload Build Artifact
-          uses: actions/upload-artifact@v2
-          with:
-            name: ${{ github.event.repository.name }}-${{ env.MODULE_VERSION }}.jar
-            path: modules/${{ github.event.repository.name }}/build/libs/${{ github.event.repository.name }}-${{ env.MODULE_VERSION }}.jar
-            shell: bash

--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -1,0 +1,58 @@
+name: Build, Test, and Upload Artifacts
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+
+jobs:
+  build:
+    name: Build / Test / Publish
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout Engine
+          uses: actions/checkout@v2
+          with:
+            repository: MovingBlocks/Terasology
+        - uses: actions/cache@v1
+          name: Restore gradle cache
+          with:
+            path: ~/.gradle/caches
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+            restore-keys: |
+              ${{ runner.OS }}-gradle-${{ env.cache-name }}-
+              ${{ runner.OS }}-gradle-
+              ${{ runner.OS }}-
+        - uses: actions/cache@v1
+          name: Restore gradle wrapper
+          with:
+            path: ~/.gradle/wrapper
+            key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+        - name: Checkout Module
+          uses: actions/checkout@v2
+          with:
+            path: modules/${{ github.event.repository.name }}
+        - name: Set up JDK 8
+          uses: actions/setup-java@v1
+          with:
+            java-version: 8
+        - name: Refresh Module Build Files
+          run: ./groovyw module refresh
+        - name: Get module version
+          run: echo ::set-env name=MODULE_VERSION::$(./gradlew :modules:${{ github.event.repository.name }}:properties | grep "version:" | awk '{print $2}')
+          shell: bash
+        - name: Build module JAR
+          run: ./gradlew :modules:${{ github.event.repository.name }}:jar
+        - name: Test
+          run: ./gradlew :modules:${{ github.event.repository.name }}:test
+        - name: Check
+          run: ./gradlew :modules:${{ github.event.repository.name }}:check
+          continue-on-error: true
+        - name: Upload Build Artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: ${{ github.event.repository.name }}-${{ env.MODULE_VERSION }}.jar
+            path: modules/${{ github.event.repository.name }}/build/libs/${{ github.event.repository.name }}-${{ env.MODULE_VERSION }}.jar
+            shell: bash


### PR DESCRIPTION
Add a Github Workflow using [actions](https://github.com/features/actions) do build and test the module. 

Publishes the JUnit test results via [check-run-reporter](https://www.check-run-reporter.com/).

The workflow does a checkout of the engine repo to be in a "full" environment in which also the MTE is working. We may apply the same pattern with Jenkins and remove this workflow at some later point.