### PR TITLE
feat: add `addToBlockBasedItem` annotation to `InventoryComponent`

### DIFF
--- a/src/main/java/org/terasology/logic/inventory/InventoryComponent.java
+++ b/src/main/java/org/terasology/logic/inventory/InventoryComponent.java
@@ -24,14 +24,15 @@ import org.terasology.network.Replicate;
 import org.terasology.network.ReplicationCheck;
 import org.terasology.reflection.metadata.FieldMetadata;
 import org.terasology.world.block.ForceBlockActive;
+import org.terasology.world.block.items.AddToBlockBasedItem;
 
 import java.util.List;
 
 /**
  * Allows an entity to store items.
- *
  */
 @ForceBlockActive
+@AddToBlockBasedItem
 public final class InventoryComponent implements Component, ReplicationCheck {
 
     public boolean privateToOwner = true;


### PR DESCRIPTION
Fixes #16 

When trying to nest items in a chest before ever having placed the chest, this doesn't work as the block based item "chest" doesn't have an `InventoryComponent` because this annotation is missing