### PR TITLE
feat: add inventory screen titles

### DIFF
--- a/assets/skins/inventoryDefault.skin
+++ b/assets/skins/inventoryDefault.skin
@@ -37,5 +37,11 @@
             "fixed-width": 40,
             "fixed-height": 40
         }
+    },
+    "families": {
+        "title":{
+            "font":"NotoSans-Regular-Medium",
+			"text-align-horizontal": "left"
+        }
     }
 }

--- a/assets/skins/inventoryDefault.skin
+++ b/assets/skins/inventoryDefault.skin
@@ -39,9 +39,9 @@
         }
     },
     "families": {
-        "title":{
+        "title": {
             "font":"NotoSans-Regular-Medium",
-			"text-align-horizontal": "left"
+            "text-align-horizontal": "left"
         }
     }
 }

--- a/assets/ui/ingame/containerScreen.ui
+++ b/assets/ui/ingame/containerScreen.ui
@@ -5,17 +5,21 @@
         "type": "relativeLayout",
         "contents": [
             {
-                "type": "InventoryGrid",
-                "id": "inventory",
-                "maxHorizontalCells": 10,
+                "type": "UILabel",
+                "id": "containerTitle",
+                "family": "title",
                 "layoutInfo": {
+                    "height": 30,
                     "use-content-width": true,
-                    "use-content-height": true,
-                    "position-bottom": {
-                        "target": "BOTTOM",
-                        "offset": 128
+                    "position-left": {
+                        "target": "LEFT",
+                        "widget": "container"
                     },
-                    "position-horizontal-center": {}
+                    "position-bottom": {
+                        "target": "TOP",
+                        "widget": "container",
+                        "offset": 10
+                    }
                 }
             },
             {
@@ -25,12 +29,42 @@
                 "layoutInfo": {
                     "use-content-width": true,
                     "use-content-height": true,
-                    "position-bottom": {
-                        "target": "TOP",
-                        "widget": "inventory",
-                        "offset": 16
+                    "position-horizontal-center": {},
+                    "position-vertical-center": {}
+                }
+            },
+            {
+                "type": "UILabel",
+                "id": "inventoryTitle",
+                "family": "title",
+                "text": "${engine:menu#category-inventory}",
+                "layoutInfo": {
+                    "height": 30,
+                    "use-content-width": true,
+                    "position-left": {
+                        "target": "LEFT",
+                        "widget": "container"
                     },
-                    "position-horizontal-center": {}
+                    "position-top": {
+                        "target": "BOTTOM",
+                        "widget": "container",
+                        "offset": 16
+                    }
+                }
+            },
+            {
+                "type": "InventoryGrid",
+                "id": "inventory",
+                "maxHorizontalCells": 10,
+                "layoutInfo": {
+                    "use-content-width": true,
+                    "use-content-height": true,
+                    "position-horizontal-center": {},
+                    "position-top": {
+                        "target": "BOTTOM",
+                        "widget": "inventoryTitle",
+                        "offset": 10
+                    }
                 }
             }
         ]

--- a/assets/ui/ingame/inventoryScreen.ui
+++ b/assets/ui/ingame/inventoryScreen.ui
@@ -12,10 +12,14 @@
                 "layoutInfo": {
                     "height": 30,
                     "use-content-width": true,
-                    "position-vertical-center": {},
                     "position-left": {
                         "target": "LEFT",
                         "widget": "inventory"
+                    },
+                    "position-bottom": {
+                        "target": "TOP",
+                        "widget": "inventory",
+                        "offset": 10
                     }
                 }
             },
@@ -25,20 +29,12 @@
                 "maxHorizontalCells": 10,
                 "layoutInfo": {
                     "use-content-width": true,
+                    "use-content-height": true,
                     "position-horizontal-center": {},
-                    "position-top": {
-                        "target": "BOTTOM",
-                        "widget": "title",
-                        "offset": 10
-                    }
+                    "position-vertical-center": {}
                 }
             }
-        ],
-        "layoutInfo": {
-            "position-horizontal-center": {},
-            "use-content-width": true,
-            "use-content-height": true
-        }
+        ]
     }
 }
 

--- a/assets/ui/ingame/inventoryScreen.ui
+++ b/assets/ui/ingame/inventoryScreen.ui
@@ -5,16 +5,40 @@
         "type": "relativeLayout",
         "contents": [
             {
+                "type": "UILabel",
+                "id": "title",
+                "family": "title",
+                "text": "${engine:menu#category-inventory}",
+                "layoutInfo": {
+                    "height": 30,
+                    "use-content-width": true,
+                    "position-vertical-center": {},
+                    "position-left": {
+                        "target": "LEFT",
+                        "widget": "inventory"
+                    }
+                }
+            },
+            {
                 "type": "InventoryGrid",
                 "id": "inventory",
                 "maxHorizontalCells": 10,
                 "layoutInfo": {
                     "use-content-width": true,
-                    "use-content-height": true,
                     "position-horizontal-center": {},
-                    "position-vertical-center": {}
+                    "position-top": {
+                        "target": "BOTTOM",
+                        "widget": "title",
+                        "offset": 10
+                    }
                 }
             }
-        ]
+        ],
+        "layoutInfo": {
+            "position-horizontal-center": {},
+            "use-content-width": true,
+            "use-content-height": true
+        }
     }
 }
+

--- a/src/main/java/org/terasology/module/inventory/ui/ContainerScreen.java
+++ b/src/main/java/org/terasology/module/inventory/ui/ContainerScreen.java
@@ -3,11 +3,16 @@
 package org.terasology.module.inventory.ui;
 
 import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.prefab.Prefab;
 import org.terasology.engine.logic.characters.CharacterComponent;
+import org.terasology.engine.logic.common.DisplayNameComponent;
 import org.terasology.engine.logic.players.LocalPlayer;
 import org.terasology.nui.databinding.ReadOnlyBinding;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.CoreScreenLayer;
+import org.terasology.nui.widgets.UILabel;
+
+import java.util.Optional;
 
 /**
  */
@@ -29,13 +34,27 @@ public class ContainerScreen extends CoreScreenLayer {
         });
         inventory.setCellOffset(10);
 
+        UILabel containerTitle = find("containerTitle", UILabel.class);
         containerInventory = find("container", InventoryGrid.class);
+
+        EntityRef characterEntity = localPlayer.getCharacterEntity();
+        CharacterComponent characterComponent = characterEntity.getComponent(CharacterComponent.class);
         containerInventory.bindTargetEntity(new ReadOnlyBinding<EntityRef>() {
             @Override
             public EntityRef get() {
-                EntityRef characterEntity = localPlayer.getCharacterEntity();
-                CharacterComponent characterComponent = characterEntity.getComponent(CharacterComponent.class);
                 return characterComponent.predictedInteractionTarget;
+            }
+        });
+        containerTitle.bindText(new ReadOnlyBinding<String>() {
+            @Override
+            public String get() {
+                Prefab parentPrefab = characterComponent.predictedInteractionTarget.getParentPrefab();
+                DisplayNameComponent displayName = parentPrefab.getComponent(DisplayNameComponent.class);
+                if (displayName != null) {
+                    return displayName.name;
+                } else {
+                    return parentPrefab.getName();
+                }
             }
         });
     }

--- a/src/main/java/org/terasology/module/inventory/ui/ContainerScreen.java
+++ b/src/main/java/org/terasology/module/inventory/ui/ContainerScreen.java
@@ -38,17 +38,16 @@ public class ContainerScreen extends CoreScreenLayer {
         containerInventory = find("container", InventoryGrid.class);
 
         EntityRef characterEntity = localPlayer.getCharacterEntity();
-        CharacterComponent characterComponent = characterEntity.getComponent(CharacterComponent.class);
         containerInventory.bindTargetEntity(new ReadOnlyBinding<EntityRef>() {
             @Override
             public EntityRef get() {
-                return characterComponent.predictedInteractionTarget;
+                return characterEntity.getComponent(CharacterComponent.class).predictedInteractionTarget;
             }
         });
         containerTitle.bindText(new ReadOnlyBinding<String>() {
             @Override
             public String get() {
-                Prefab parentPrefab = characterComponent.predictedInteractionTarget.getParentPrefab();
+                Prefab parentPrefab = characterEntity.getComponent(CharacterComponent.class).predictedInteractionTarget.getParentPrefab();
                 DisplayNameComponent displayName = parentPrefab.getComponent(DisplayNameComponent.class);
                 if (displayName != null) {
                     return displayName.name;

--- a/src/main/java/org/terasology/module/inventory/ui/ContainerScreen.java
+++ b/src/main/java/org/terasology/module/inventory/ui/ContainerScreen.java
@@ -4,15 +4,14 @@ package org.terasology.module.inventory.ui;
 
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.prefab.Prefab;
+import org.terasology.engine.i18n.TranslationSystem;
 import org.terasology.engine.logic.characters.CharacterComponent;
 import org.terasology.engine.logic.common.DisplayNameComponent;
 import org.terasology.engine.logic.players.LocalPlayer;
-import org.terasology.nui.databinding.ReadOnlyBinding;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.CoreScreenLayer;
+import org.terasology.nui.databinding.ReadOnlyBinding;
 import org.terasology.nui.widgets.UILabel;
-
-import java.util.Optional;
 
 /**
  */
@@ -20,6 +19,9 @@ public class ContainerScreen extends CoreScreenLayer {
 
     @In
     private LocalPlayer localPlayer;
+
+    @In
+    private TranslationSystem i18n;
 
     private InventoryGrid containerInventory;
 
@@ -51,7 +53,10 @@ public class ContainerScreen extends CoreScreenLayer {
                 Prefab parentPrefab = characterComponent.predictedInteractionTarget.getParentPrefab();
                 DisplayNameComponent displayName = parentPrefab.getComponent(DisplayNameComponent.class);
                 if (displayName != null) {
-                    return displayName.name;
+                    // The display name may contain a translatable string reference, thus we attempt to get the translation.
+                    // If the string is just non-translatable display name the fallback mechanism will yield just the input string.
+                    // NOTE: Unfortunately, this contract is not guaranteed by `TranslationSystem#translate(String)`.
+                    return i18n.translate(displayName.name);
                 } else {
                     return parentPrefab.getName();
                 }


### PR DESCRIPTION
This PR adds a (translated) title to the inventory screen.

![image](https://user-images.githubusercontent.com/29981695/128411218-747faa94-ea68-46ae-a0e3-c6fba53ffa36.png)

In itself this doesn't do much yet and might seem unnecessary. However, especially when using item blocks that have an inventory (chests, assembly tables, etc.), it easily becomes confusing, which inventory is the own and which is the inventory of the block being interacted with. Hence, I added this for container inventory as well.

If the container parent prefab does not have a `DisplayNameComponent`, the prefab name will be shown, for instance `CoreAdvancedAssets:chest`. https://github.com/Terasology/CoreAdvancedAssets/pull/5 adds a `DisplayNameComponent` to the chest prefab.

![image](https://user-images.githubusercontent.com/29981695/128424912-c47b8da1-1195-43df-92ea-1f6420b6e1d3.png)

This should result in a first improvement and can be further extended by applying similar changes to items with inventory slots, for instance elements of Josharias' Survival.
